### PR TITLE
Implemented GetOrPut operation.

### DIFF
--- a/lru.go
+++ b/lru.go
@@ -25,6 +25,11 @@ type Cache interface {
 	// Get gets the item from the cache and pushes it to the front.
 	Get(k string) (interface{}, bool)
 
+	// GetOrPut returns the existing value for the key if present.
+	// Otherwise, it stores and returns the given value. The bool
+	// result is true if the value was loaded, false if stored.
+	GetOrPut(k string, v interface{}) (interface{}, bool)
+
 	// Del removes the item from the cache.
 	Del(k string)
 
@@ -75,7 +80,10 @@ func (c *lru) Put(k string, v interface{}) {
 	}
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
+	c.put(k, v)
+}
 
+func (c *lru) put(k string, v interface{}) {
 	timeout := atomic.LoadUint64(&c.timeout)
 
 	e, ok := c.lookup[k]
@@ -113,6 +121,26 @@ func (c *lru) Get(k string) (interface{}, bool) {
 		}
 	}
 	return nil, false
+}
+
+func (c *lru) GetOrPut(k string, v interface{}) (interface{}, bool) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	if e, ok := c.lookup[k]; ok {
+		timeout := e.Value.(*lruItem).timeout
+		if timeout > 0 && nowMs() > timeout {
+			c.list.Remove(e)
+			delete(c.lookup, k)
+		} else {
+			c.list.MoveToFront(e)
+			return e.Value.(*lruItem).value, true
+		}
+	}
+	if v == nil {
+		return nil, false
+	}
+	c.put(k, v)
+	return v, false
 }
 
 func (c *lru) Del(k string) {

--- a/lru.go
+++ b/lru.go
@@ -110,6 +110,10 @@ func (c *lru) put(k string, v interface{}) {
 func (c *lru) Get(k string) (interface{}, bool) {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
+	return c.get(k)
+}
+
+func (c *lru) get(k string) (interface{}, bool) {
 	if e, ok := c.lookup[k]; ok {
 		timeout := e.Value.(*lruItem).timeout
 		if timeout > 0 && nowMs() > timeout {
@@ -126,15 +130,8 @@ func (c *lru) Get(k string) (interface{}, bool) {
 func (c *lru) GetOrPut(k string, v interface{}) (interface{}, bool) {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
-	if e, ok := c.lookup[k]; ok {
-		timeout := e.Value.(*lruItem).timeout
-		if timeout > 0 && nowMs() > timeout {
-			c.list.Remove(e)
-			delete(c.lookup, k)
-		} else {
-			c.list.MoveToFront(e)
-			return e.Value.(*lruItem).value, true
-		}
+	if e, ok := c.get(k); ok {
+		return e, ok
 	}
 	if v == nil {
 		return nil, false

--- a/lru_test.go
+++ b/lru_test.go
@@ -83,6 +83,43 @@ func TestCache(t *testing.T) {
 	}
 }
 
+func TestGetOrPut(t *testing.T) {
+	c := New()
+	v, loaded := c.GetOrPut(`a`, 1)
+	if loaded {
+		t.Fatal()
+	}
+	if x := v.(int); x != 1 {
+		t.Fatal(x)
+	}
+
+	c.Put(`b`, 2)
+	v, loaded = c.GetOrPut(`b`, nil)
+	if !loaded {
+		t.Fatal()
+	}
+	if x := v.(int); x != 2 {
+		t.Fatal(x)
+	}
+
+	c.Put(`c`, 3)
+	v, loaded = c.GetOrPut(`c`, 4)
+	if !loaded {
+		t.Fatal()
+	}
+	if x := v.(int); x != 3 {
+		t.Fatal(x)
+	}
+
+	v, loaded = c.GetOrPut(`d`, nil)
+	if loaded {
+		t.Fatal()
+	}
+	if v != nil {
+		t.Fatal()
+	}
+}
+
 func TestPutReplace(t *testing.T) {
 	c := New()
 	c.Put(`a`, 1)


### PR DESCRIPTION
Similar to the standard library syncmap.Map's LoadOrStore, the GetOrPut returns the existing value for the key if present. Otherwise, it stores and returns the given value. The bool result is true if the value was loaded, false if stored.

I have a requirement to get or/and put under a mutex lock. I think this will be beneficial for everyone.